### PR TITLE
Add daily correct-answer popup, synonym tracking, and EC2 deployment pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,63 @@
+name: Deploy to EC2
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build application
+        run: npm run build
+
+      - name: Build Docker image
+        run: docker build -t english-words-app:latest .
+
+      - name: Save Docker image
+        run: docker save english-words-app:latest -o image.tar
+
+      - name: Copy image to EC2
+        env:
+          SSH_KEY: ${{ vars.EC2_SSH_KEY }}
+          EC2_USER: ${{ vars.EC2_USER }}
+          EC2_HOST: ${{ vars.EC2_HOST }}
+        run: |
+          echo "$SSH_KEY" > key.pem
+          chmod 600 key.pem
+          scp -o StrictHostKeyChecking=no -i key.pem image.tar $EC2_USER@$EC2_HOST:~/image.tar
+
+      - name: Deploy on EC2
+        env:
+          SSH_KEY: ${{ vars.EC2_SSH_KEY }}
+          EC2_USER: ${{ vars.EC2_USER }}
+          EC2_HOST: ${{ vars.EC2_HOST }}
+        run: |
+          echo "$SSH_KEY" > key.pem
+          chmod 600 key.pem
+          ssh -o StrictHostKeyChecking=no -i key.pem $EC2_USER@$EC2_HOST <<'CMD'
+            docker load -i image.tar
+            docker stop english-words-app || true
+            docker rm english-words-app || true
+            docker run -d --name english-words-app -p 80:5000 english-words-app:latest
+            for i in {1..10}; do
+              if docker ps | grep english-words-app >/dev/null; then
+                echo "Container started"
+                exit 0
+              fi
+              sleep 3
+            done
+            echo "Container failed to start"
+            exit 1
+          CMD

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Stage 1: build application
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY prisma ./prisma
+RUN npx prisma generate
+COPY tsconfig.json ./
+COPY server ./server
+RUN npm run build:server
+COPY client ./client
+RUN cd client && npm install && npm run build
+
+# Stage 2: production image
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+COPY prisma ./prisma
+RUN npm install --only=production \ 
+    && npx prisma generate
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/client/build ./client/build
+ENV NODE_ENV=production
+EXPOSE 5000
+CMD ["node", "dist/server/index.js"]

--- a/client/src/components/StudyCard.tsx
+++ b/client/src/components/StudyCard.tsx
@@ -10,6 +10,7 @@ import {
   Chip,
   IconButton,
   Tooltip,
+  Snackbar,
 } from '@mui/material';
 import {
   Favorite,
@@ -36,6 +37,8 @@ export const StudyCard: React.FC<StudyCardProps> = ({
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isExampleRevealed, setIsExampleRevealed] = useState(false);
+  const [snackbarOpen, setSnackbarOpen] = useState(false);
+  const [todayCorrectAnswers, setTodayCorrectAnswers] = useState(0);
   const autoAdvanceTimeoutRef = useRef<number | null>(null);
 
   const loadNextWord = async (excludeCurrent: boolean = false) => {
@@ -71,8 +74,10 @@ export const StudyCard: React.FC<StudyCardProps> = ({
         wordId: currentWord.id,
         answer: answer.trim(),
       });
-      
+
       setResult(result);
+      setTodayCorrectAnswers(result.todayCorrectAnswers);
+      setSnackbarOpen(true);
       
       if (result.isCorrect) {
         if (autoAdvanceTimeoutRef.current) {
@@ -147,6 +152,7 @@ export const StudyCard: React.FC<StudyCardProps> = ({
   }
 
   return (
+    <>
     <Card sx={{ minWidth: 400, maxWidth: 600 }}>
       <CardContent>
         <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
@@ -287,5 +293,16 @@ export const StudyCard: React.FC<StudyCardProps> = ({
         </Button>
       </CardContent>
     </Card>
+    <Snackbar
+      open={snackbarOpen}
+      autoHideDuration={3000}
+      onClose={() => setSnackbarOpen(false)}
+      anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+    >
+      <Alert onClose={() => setSnackbarOpen(false)} severity="info" sx={{ width: '100%' }}>
+        Correct answers today: {todayCorrectAnswers}
+      </Alert>
+    </Snackbar>
+    </>
   );
 };

--- a/client/src/components/StudyCard.tsx
+++ b/client/src/components/StudyCard.tsx
@@ -103,7 +103,9 @@ export const StudyCard: React.FC<StudyCardProps> = ({
       });
       setResult(result);
       setTodayCorrectAnswers(result.todayCorrectAnswers);
-      setSnackbarOpen(true);
+      if (result.isCorrect || result.isSynonym) {
+        setSnackbarOpen(true);
+      }
       if (result.isSynonym) {
         setEnteredSynonyms((prev) => [...prev, answer]);
         setAnswer('');

--- a/client/src/components/StudyCard.tsx
+++ b/client/src/components/StudyCard.tsx
@@ -61,11 +61,11 @@ export const StudyCard: React.FC<StudyCardProps> = ({
     try {
       setLoading(true);
       setError(null);
-      const word = await wordsApi.getStudyWord(
+      const studyWordResponse = await wordsApi.getStudyWord(
         favoriteOnly,
         excludeCurrent && currentWord ? currentWord.id : undefined
       );
-      setCurrentWord(word);
+      setCurrentWord(studyWordResponse.word);
       setAnswer('');
       setResult(null);
       setIsExampleRevealed(false);

--- a/client/src/components/StudyCard.tsx
+++ b/client/src/components/StudyCard.tsx
@@ -11,6 +11,10 @@ import {
   IconButton,
   Tooltip,
   Snackbar,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
 } from '@mui/material';
 import {
   Favorite,
@@ -18,8 +22,9 @@ import {
   CheckCircle,
   Error,
   Info,
+  Edit,
 } from '@mui/icons-material';
-import { Word, CheckAnswerResponse } from '../types';
+import { Word, CheckAnswerResponse, UpdateWordRequest } from '../types';
 import { wordsApi, answersApi } from '../services/api';
 
 interface StudyCardProps {
@@ -31,6 +36,9 @@ export const StudyCard: React.FC<StudyCardProps> = ({
   onWordCompleted, 
   favoriteOnly = false 
 }) => {
+  const [isAnswerRevealed, setIsAnswerRevealed] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [shouldFocusInput, setShouldFocusInput] = useState(false);
   const [currentWord, setCurrentWord] = useState<Word | null>(null);
   const [answer, setAnswer] = useState('');
   const [result, setResult] = useState<CheckAnswerResponse | null>(null);
@@ -39,6 +47,14 @@ export const StudyCard: React.FC<StudyCardProps> = ({
   const [isExampleRevealed, setIsExampleRevealed] = useState(false);
   const [snackbarOpen, setSnackbarOpen] = useState(false);
   const [todayCorrectAnswers, setTodayCorrectAnswers] = useState(0);
+  const [editDialogOpen, setEditDialogOpen] = useState(false);
+  const [formData, setFormData] = useState<UpdateWordRequest>({
+    english: '',
+    russian: '',
+    exampleEn: '',
+    exampleRu: '',
+  });
+  const [enteredSynonyms, setEnteredSynonyms] = useState<string[]>([]);
   const autoAdvanceTimeoutRef = useRef<number | null>(null);
 
   const loadNextWord = async (excludeCurrent: boolean = false) => {
@@ -53,12 +69,23 @@ export const StudyCard: React.FC<StudyCardProps> = ({
       setAnswer('');
       setResult(null);
       setIsExampleRevealed(false);
+      setIsAnswerRevealed(false);
+      setShouldFocusInput(true);
     } catch (err: unknown) {
       setError('Failed to load word');
     } finally {
       setLoading(false);
     }
   };
+
+  useEffect(() => {
+    if (shouldFocusInput) {
+      setShouldFocusInput(false);
+      setTimeout(() => {
+        inputRef.current?.focus();
+      }, 0);
+    }
+  }, [shouldFocusInput, currentWord]);
 
   useEffect(() => {
     loadNextWord();
@@ -74,12 +101,16 @@ export const StudyCard: React.FC<StudyCardProps> = ({
         wordId: currentWord.id,
         answer: answer.trim(),
       });
-
       setResult(result);
       setTodayCorrectAnswers(result.todayCorrectAnswers);
       setSnackbarOpen(true);
-      
+      if (result.isSynonym) {
+        setEnteredSynonyms((prev) => [...prev, answer]);
+        setAnswer('');
+        setShouldFocusInput(true);
+      }
       if (result.isCorrect) {
+        setEnteredSynonyms([]);
         if (autoAdvanceTimeoutRef.current) {
           window.clearTimeout(autoAdvanceTimeoutRef.current);
           autoAdvanceTimeoutRef.current = null;
@@ -105,6 +136,33 @@ export const StudyCard: React.FC<StudyCardProps> = ({
       setCurrentWord(updatedWord);
     } catch (err: unknown) {
       setError('Failed to toggle favorite');
+    }
+  };
+
+  const handleEditOpen = () => {
+    if (!currentWord) return;
+    setFormData({
+      english: currentWord.english,
+      russian: currentWord.russian,
+      exampleEn: currentWord.exampleEn,
+      exampleRu: currentWord.exampleRu,
+    });
+    setEditDialogOpen(true);
+  };
+
+  const handleSaveEdit = async () => {
+    if (!currentWord) return;
+
+    try {
+      await wordsApi.update(currentWord.id, formData);
+      setEditDialogOpen(false);
+      if (autoAdvanceTimeoutRef.current) {
+        window.clearTimeout(autoAdvanceTimeoutRef.current);
+        autoAdvanceTimeoutRef.current = null;
+      }
+      loadNextWord(true);
+    } catch (err: unknown) {
+      setError('Failed to save word');
     }
   };
 
@@ -153,17 +211,24 @@ export const StudyCard: React.FC<StudyCardProps> = ({
 
   return (
     <>
-    <Card sx={{ minWidth: 400, maxWidth: 600 }}>
-      <CardContent>
+      <Card sx={{ minWidth: 400, maxWidth: 600 }}>
+        <CardContent>
         <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
           <Typography variant="h5" component="div">
             {currentWord.russian}
           </Typography>
-          <Tooltip title={currentWord.isFavorite ? 'Remove from favorites' : 'Add to favorites'}>
-            <IconButton onClick={handleToggleFavorite} color="primary">
-              {currentWord.isFavorite ? <Favorite /> : <FavoriteBorder />}
-            </IconButton>
-          </Tooltip>
+          <Box display="flex" alignItems="center">
+            <Tooltip title={currentWord.isFavorite ? 'Remove from favorites' : 'Add to favorites'}>
+              <IconButton onClick={handleToggleFavorite} color="primary">
+                {currentWord.isFavorite ? <Favorite /> : <FavoriteBorder />}
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Edit word">
+              <IconButton onClick={handleEditOpen} color="primary">
+                <Edit />
+              </IconButton>
+            </Tooltip>
+          </Box>
         </Box>
 
         <Box mb={3}>
@@ -208,16 +273,26 @@ export const StudyCard: React.FC<StudyCardProps> = ({
           </Box>
         </Box>
 
-        <form onSubmit={handleSubmit}>
+  <form onSubmit={handleSubmit}>
+
           <TextField
             fullWidth
             label="Enter English word"
             value={answer}
             onChange={(e) => setAnswer(e.target.value)}
-            disabled={loading || result?.isCorrect || isExampleRevealed}
-            autoFocus
+            disabled={loading || result?.isCorrect || isExampleRevealed || isAnswerRevealed}
+            inputRef={inputRef}
             sx={{ mb: 2 }}
+            autoComplete="off"
           />
+
+          {isAnswerRevealed && (
+            <Box mb={1}>
+              <Alert icon={<CheckCircle />} severity="info">
+                Correct answer: <strong>{currentWord.english}</strong>
+              </Alert>
+            </Box>
+          )}
 
           {isExampleRevealed && (
             <Box mb={2}>
@@ -235,7 +310,12 @@ export const StudyCard: React.FC<StudyCardProps> = ({
                 </Alert>
               ) : result.isSynonym ? (
                 <Alert icon={<Info />} severity="info">
-                  Это синоним. Попробуйте другое слово.
+                  This is synonym, try another word. Entered synonyms:<br></br>
+                  <ul style={{ margin: 0, paddingLeft: 20 }}>
+                    {enteredSynonyms.map((syn, idx) => (
+                      <li key={idx}><strong>{syn}</strong></li>
+                    ))}
+                  </ul>
                 </Alert>
               ) : result.isPartial ? (
                 <Alert icon={<Info />} severity="info">
@@ -250,28 +330,25 @@ export const StudyCard: React.FC<StudyCardProps> = ({
           )}
 
           <Button
+            variant="text"
+            color="secondary"
+            fullWidth
+            sx={{ mt: 1, mb: 1 }}
+            onClick={() => setIsAnswerRevealed(true)}
+            disabled={isAnswerRevealed || Boolean(result && !result.isCorrect && !result.isPartial && !result.isSynonym)}
+          >
+            Show Answer
+          </Button>
+
+          <Button
             type="submit"
             variant="contained"
             fullWidth
-            disabled={loading || !answer.trim() || result?.isCorrect || isExampleRevealed}
+            disabled={loading || !answer.trim() || result?.isCorrect || isExampleRevealed || isAnswerRevealed || Boolean(result && !result.isCorrect && !result.isPartial && !result.isSynonym)}
           >
             {loading ? 'Checking...' : 'Check Answer'}
           </Button>
         </form>
-
-        {result && !result.isCorrect && (
-          <Button
-            variant="outlined"
-            fullWidth
-            sx={{ mt: 1 }}
-            onClick={() => {
-              setAnswer('');
-              setResult(null);
-            }}
-          >
-            Try Again
-          </Button>
-        )}
 
         <Button
           variant="text"
@@ -279,6 +356,7 @@ export const StudyCard: React.FC<StudyCardProps> = ({
           sx={{ mt: 1 }}
           disabled={loading}
           onClick={() => {
+            setEnteredSynonyms([]);
             if (autoAdvanceTimeoutRef.current) {
               window.clearTimeout(autoAdvanceTimeoutRef.current);
               autoAdvanceTimeoutRef.current = null;
@@ -291,18 +369,60 @@ export const StudyCard: React.FC<StudyCardProps> = ({
         >
           Next
         </Button>
-      </CardContent>
-    </Card>
-    <Snackbar
-      open={snackbarOpen}
-      autoHideDuration={3000}
-      onClose={() => setSnackbarOpen(false)}
-      anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
-    >
-      <Alert onClose={() => setSnackbarOpen(false)} severity="info" sx={{ width: '100%' }}>
-        Correct answers today: {todayCorrectAnswers}
-      </Alert>
-    </Snackbar>
+        </CardContent>
+      </Card>
+      <Snackbar
+        open={snackbarOpen}
+        autoHideDuration={3000}
+        onClose={() => setSnackbarOpen(false)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      >
+        <Alert onClose={() => setSnackbarOpen(false)} severity="info" sx={{ width: '100%' }}>
+          Correct answers today: {todayCorrectAnswers}
+        </Alert>
+      </Snackbar>
+
+      <Dialog open={editDialogOpen} onClose={() => setEditDialogOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>Edit Word</DialogTitle>
+        <DialogContent>
+          <TextField
+            fullWidth
+            label="English"
+            value={formData.english}
+            onChange={(e) => setFormData({ ...formData, english: e.target.value })}
+            margin="normal"
+          />
+          <TextField
+            fullWidth
+            label="Russian"
+            value={formData.russian}
+            onChange={(e) => setFormData({ ...formData, russian: e.target.value })}
+            margin="normal"
+          />
+          <TextField
+            fullWidth
+            label="Example (English)"
+            value={formData.exampleEn}
+            onChange={(e) => setFormData({ ...formData, exampleEn: e.target.value })}
+            margin="normal"
+            multiline
+            rows={2}
+          />
+          <TextField
+            fullWidth
+            label="Example (Russian)"
+            value={formData.exampleRu}
+            onChange={(e) => setFormData({ ...formData, exampleRu: e.target.value })}
+            margin="normal"
+            multiline
+            rows={2}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setEditDialogOpen(false)}>Cancel</Button>
+          <Button onClick={handleSaveEdit} variant="contained">Save</Button>
+        </DialogActions>
+      </Dialog>
     </>
   );
 };

--- a/client/src/services/api.ts
+++ b/client/src/services/api.ts
@@ -6,7 +6,8 @@ import {
   CheckAnswerRequest, 
   CheckAnswerResponse, 
   ApiResponse, 
-  Stats 
+  Stats, 
+  StudyWordResponse
 } from '../types';
 
 const API_BASE_URL = process.env.REACT_APP_API_URL || 'http://localhost:5500/api';
@@ -33,11 +34,11 @@ export const wordsApi = {
     return response.data.data!;
   },
 
-  getStudyWord: async (favoriteOnly: boolean = false, excludeId?: number): Promise<Word> => {
+  getStudyWord: async (favoriteOnly: boolean = false, excludeId?: number): Promise<StudyWordResponse> => {
     const params = new URLSearchParams();
     params.set('favoriteOnly', String(favoriteOnly));
     if (excludeId) params.set('excludeId', String(excludeId));
-    const response = await api.get<ApiResponse<Word>>(`/words/study?${params.toString()}`);
+    const response = await api.get<ApiResponse<StudyWordResponse>>(`/words/study?${params.toString()}`);
     if (!response.data.success) {
       throw new Error(response.data.error);
     }

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -44,6 +44,7 @@ export interface CheckAnswerResponse {
   hint?: string;
   isSynonym?: boolean;
   correctAnswer: string;
+  todayCorrectAnswers: number;
 }
 
 export interface ApiResponse<T> {

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -9,6 +9,11 @@ export interface Word {
   isFavorite: boolean;
 }
 
+export interface StudyWordResponse {
+  word: Word;
+  unlearnedCount: number;
+}
+
 export interface Answer {
   id: number;
   wordId: number;

--- a/server/routes/answers.ts
+++ b/server/routes/answers.ts
@@ -42,8 +42,9 @@ router.post('/check', async (req: Request<{}, {}, CheckAnswerRequest>, res: Resp
     
     // Проверить, является ли ответ синонимом (другое англ. слово с тем же русским переводом)
     let isSynonym = false;
+    let synonymWord: { id: number } | null = null;
     if (!isCorrect) {
-      const synonymWord = await prisma.word.findFirst({
+      synonymWord = await prisma.word.findFirst({
         where: {
           russian: word.russian,
           english: userAnswer,
@@ -83,13 +84,46 @@ router.post('/check', async (req: Request<{}, {}, CheckAnswerRequest>, res: Resp
         isSynonym
       }
     });
+
+    // Если введено слово-синоним, пометить его как изученное
+    if (isSynonym && synonymWord) {
+      const existingCorrect = await prisma.answer.findFirst({
+        where: { wordId: synonymWord.id, isCorrect: true }
+      });
+      if (!existingCorrect) {
+        await prisma.answer.create({
+          data: {
+            wordId: synonymWord.id,
+            answer: userAnswer,
+            isCorrect: true
+          }
+        });
+      }
+    }
+
+    // Посчитать количество правильных ответов за сегодня
+    const startOfDay = new Date();
+    startOfDay.setHours(0, 0, 0, 0);
+    const endOfDay = new Date();
+    endOfDay.setHours(23, 59, 59, 999);
+
+    const todayCorrectAnswers = await prisma.answer.count({
+      where: {
+        isCorrect: true,
+        createdAt: {
+          gte: startOfDay,
+          lte: endOfDay
+        }
+      }
+    });
     
     const response: CheckAnswerResponse = {
       isCorrect,
       isPartial,
       hint: isSynonym ? 'Это синоним. Попробуйте другое слово.' : (isPartial ? hint : undefined),
       isSynonym: isSynonym || undefined,
-      correctAnswer: word.english
+      correctAnswer: word.english,
+      todayCorrectAnswers
     };
     
     return res.json({ success: true, data: response });

--- a/server/types/index.ts
+++ b/server/types/index.ts
@@ -44,6 +44,7 @@ export interface CheckAnswerResponse {
   hint?: string;
   isSynonym?: boolean;
   correctAnswer: string;
+  todayCorrectAnswers: number;
 }
 
 export interface WordWithAnswers extends Word {

--- a/server/types/index.ts
+++ b/server/types/index.ts
@@ -9,6 +9,11 @@ export interface Word {
   isFavorite: boolean;
 }
 
+export interface StudyWordResponse {
+  word: Word;
+  unlearnedCount: number;
+}
+
 export interface Answer {
   id: number;
   wordId: number;


### PR DESCRIPTION
## Summary
- show a bottom-right Snackbar after answers with today's correct count
- record synonym answers as learned and return daily correct stats
- add Dockerfile and GitHub Actions workflow to deploy to EC2 using variables

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68a43533e7fc832bbbaff2dc0abc663b