### PR TITLE
Add daily correct-answer popup, synonym tracking, and EC2 deployment pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,63 @@
+name: Deploy to EC2
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Build application
+        run: npm run build
+
+      - name: Build Docker image
+        run: docker build -t english-words-app:latest .
+
+      - name: Save Docker image
+        run: docker save english-words-app:latest -o image.tar
+
+      - name: Copy image to EC2
+        env:
+          SSH_KEY: ${{ vars.EC2_SSH_KEY }}
+          EC2_USER: ${{ vars.EC2_USER }}
+          EC2_HOST: ${{ vars.EC2_HOST }}
+        run: |
+          echo "$SSH_KEY" > key.pem
+          chmod 600 key.pem
+          scp -o StrictHostKeyChecking=no -i key.pem image.tar $EC2_USER@$EC2_HOST:~/image.tar
+
+      - name: Deploy on EC2
+        env:
+          SSH_KEY: ${{ vars.EC2_SSH_KEY }}
+          EC2_USER: ${{ vars.EC2_USER }}
+          EC2_HOST: ${{ vars.EC2_HOST }}
+        run: |
+          echo "$SSH_KEY" > key.pem
+          chmod 600 key.pem
+          ssh -o StrictHostKeyChecking=no -i key.pem $EC2_USER@$EC2_HOST <<'CMD'
+            docker load -i image.tar
+            docker stop english-words-app || true
+            docker rm english-words-app || true
+            docker run -d --name english-words-app -p 80:5000 english-words-app:latest
+            for i in {1..10}; do
+              if docker ps | grep english-words-app >/dev/null; then
+                echo "Container started"
+                exit 0
+              fi
+              sleep 3
+            done
+            echo "Container failed to start"
+            exit 1
+          CMD

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+# Stage 1: build application
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+RUN npm install
+COPY prisma ./prisma
+RUN npx prisma generate
+COPY tsconfig.json ./
+COPY server ./server
+RUN npm run build:server
+COPY client ./client
+RUN cd client && npm install && npm run build
+
+# Stage 2: production image
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+COPY prisma ./prisma
+RUN npm install --only=production \ 
+    && npx prisma generate
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/client/build ./client/build
+ENV NODE_ENV=production
+EXPOSE 5000
+CMD ["node", "dist/server/index.js"]

--- a/client/src/components/StudyCard.tsx
+++ b/client/src/components/StudyCard.tsx
@@ -33,9 +33,9 @@ interface StudyCardProps {
   favoriteOnly?: boolean;
 }
 
-export const StudyCard: React.FC<StudyCardProps> = ({ 
-  onWordCompleted, 
-  favoriteOnly = false 
+export const StudyCard: React.FC<StudyCardProps> = ({
+  onWordCompleted,
+  favoriteOnly = false
 }) => {
   const [isAnswerRevealed, setIsAnswerRevealed] = useState(false);
   const inputRef = useRef<HTMLInputElement>(null);
@@ -48,6 +48,7 @@ export const StudyCard: React.FC<StudyCardProps> = ({
   const [isExampleRevealed, setIsExampleRevealed] = useState(false);
   const [snackbarOpen, setSnackbarOpen] = useState(false);
   const [todayCorrectAnswers, setTodayCorrectAnswers] = useState(0);
+  const [totalCorrectAnswers, setTotalCorrectAnswers] = useState(0);
   const [totalWords, setTotalWords] = useState(0);
   const [editDialogOpen, setEditDialogOpen] = useState(false);
   const [formData, setFormData] = useState<UpdateWordRequest>({
@@ -105,6 +106,7 @@ export const StudyCard: React.FC<StudyCardProps> = ({
       });
       setResult(result);
       setTodayCorrectAnswers(result.todayCorrectAnswers);
+      setTotalCorrectAnswers(result.totalCorrectAnswers);
       setTotalWords(result.totalWords);
       if (result.isCorrect || result.isSynonym) {
         setSnackbarOpen(true);
@@ -135,7 +137,7 @@ export const StudyCard: React.FC<StudyCardProps> = ({
 
   const handleToggleFavorite = async () => {
     if (!currentWord) return;
-    
+
     try {
       const updatedWord = await wordsApi.toggleFavorite(currentWord.id);
       setCurrentWord(updatedWord);
@@ -205,8 +207,8 @@ export const StudyCard: React.FC<StudyCardProps> = ({
           No words available for study
         </Typography>
         <Typography color="text.secondary">
-          {favoriteOnly 
-            ? 'Add some words to favorites to study them' 
+          {favoriteOnly
+            ? 'Add some words to favorites to study them'
             : 'Add some words to start studying'
           }
         </Typography>
@@ -218,162 +220,162 @@ export const StudyCard: React.FC<StudyCardProps> = ({
     <>
       <Card sx={{ minWidth: 400, maxWidth: 600 }}>
         <CardContent>
-        <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
-          <Typography variant="h5" component="div">
-            {currentWord.russian}
-          </Typography>
-          <Box display="flex" alignItems="center">
-            <Tooltip title={currentWord.isFavorite ? 'Remove from favorites' : 'Add to favorites'}>
-              <IconButton onClick={handleToggleFavorite} color="primary">
-                {currentWord.isFavorite ? <Favorite /> : <FavoriteBorder />}
-              </IconButton>
-            </Tooltip>
-            <Tooltip title="Edit word">
-              <IconButton onClick={handleEditOpen} color="primary">
-                <Edit />
-              </IconButton>
-            </Tooltip>
+          <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
+            <Typography variant="h5" component="div">
+              {currentWord.russian}
+            </Typography>
+            <Box display="flex" alignItems="center">
+              <Tooltip title={currentWord.isFavorite ? 'Remove from favorites' : 'Add to favorites'}>
+                <IconButton onClick={handleToggleFavorite} color="primary">
+                  {currentWord.isFavorite ? <Favorite /> : <FavoriteBorder />}
+                </IconButton>
+              </Tooltip>
+              <Tooltip title="Edit word">
+                <IconButton onClick={handleEditOpen} color="primary">
+                  <Edit />
+                </IconButton>
+              </Tooltip>
+            </Box>
           </Box>
-        </Box>
 
-        <Box mb={3}>
-          <Typography variant="body2" color="text.secondary" gutterBottom>
-            Example in Russian:
-          </Typography>
-          <Typography variant="body1" sx={{ fontStyle: 'italic' }}>
-            {currentWord.exampleRu}
-          </Typography>
-        </Box>
+          <Box mb={3}>
+            <Typography variant="body2" color="text.secondary" gutterBottom>
+              Example in Russian:
+            </Typography>
+            <Typography variant="body1" sx={{ fontStyle: 'italic' }}>
+              {currentWord.exampleRu}
+            </Typography>
+          </Box>
 
-        <Box mb={3}>
-          <Typography variant="body2" color="text.secondary" gutterBottom>
-            Example in English:
-          </Typography>
-          <Box
-            onClick={handleRevealExample}
-            sx={{
-              position: 'relative',
-              cursor: isExampleRevealed ? 'default' : 'pointer',
-              userSelect: isExampleRevealed ? 'text' : 'none',
-            }}
-          >
-            <Typography
-              variant="body1"
+          <Box mb={3}>
+            <Typography variant="body2" color="text.secondary" gutterBottom>
+              Example in English:
+            </Typography>
+            <Box
+              onClick={handleRevealExample}
               sx={{
-                fontStyle: 'italic',
-                filter: isExampleRevealed ? 'none' : 'blur(6px)',
-                transition: 'filter 0.2s ease',
+                position: 'relative',
+                cursor: isExampleRevealed ? 'default' : 'pointer',
+                userSelect: isExampleRevealed ? 'text' : 'none',
               }}
             >
-              {currentWord.exampleEn}
-            </Typography>
-            {!isExampleRevealed && (
-              <Chip
-                size="small"
-                label="Click to reveal"
-                color="primary"
-                sx={{ position: 'absolute', top: -8, right: 0 }}
-              />
-            )}
-          </Box>
-        </Box>
-
-  <form onSubmit={handleSubmit}>
-
-          <TextField
-            fullWidth
-            label="Enter English word"
-            value={answer}
-            onChange={(e) => setAnswer(e.target.value)}
-            disabled={loading || result?.isCorrect || isExampleRevealed || isAnswerRevealed}
-            inputRef={inputRef}
-            sx={{ mb: 2 }}
-            autoComplete="off"
-          />
-
-          {isAnswerRevealed && (
-            <Box mb={1}>
-              <Alert icon={<CheckCircle />} severity="info">
-                Correct answer: <strong>{currentWord.english}</strong>
-              </Alert>
-            </Box>
-          )}
-
-          {isExampleRevealed && (
-            <Box mb={2}>
-              <Alert icon={<Info />} severity="info">
-                English example revealed. Input is locked. Click Next to continue.
-              </Alert>
-            </Box>
-          )}
-
-          {result && (
-            <Box mb={2}>
-              {result.isCorrect ? (
-                <Alert icon={<CheckCircle />} severity="success">
-                  Correct! Well done!
-                </Alert>
-              ) : result.isSynonym ? (
-                <Alert icon={<Info />} severity="info">
-                  This is synonym, try another word. Entered synonyms:<br></br>
-                  <ul style={{ margin: 0, paddingLeft: 20 }}>
-                    {enteredSynonyms.map((syn, idx) => (
-                      <li key={idx}><strong>{syn}</strong></li>
-                    ))}
-                  </ul>
-                </Alert>
-              ) : result.isPartial ? (
-                <Alert icon={<Info />} severity="info">
-                  {result.hint}
-                </Alert>
-              ) : (
-                <Alert icon={<Error />} severity="error">
-                  Incorrect. The correct answer is: <strong>{result.correctAnswer}</strong>
-                </Alert>
+              <Typography
+                variant="body1"
+                sx={{
+                  fontStyle: 'italic',
+                  filter: isExampleRevealed ? 'none' : 'blur(6px)',
+                  transition: 'filter 0.2s ease',
+                }}
+              >
+                {currentWord.exampleEn}
+              </Typography>
+              {!isExampleRevealed && (
+                <Chip
+                  size="small"
+                  label="Click to reveal"
+                  color="primary"
+                  sx={{ position: 'absolute', top: -8, right: 0 }}
+                />
               )}
             </Box>
-          )}
+          </Box>
+
+          <form onSubmit={handleSubmit}>
+
+            <TextField
+              fullWidth
+              label="Enter English word"
+              value={answer}
+              onChange={(e) => setAnswer(e.target.value)}
+              disabled={loading || result?.isCorrect || isExampleRevealed || isAnswerRevealed}
+              inputRef={inputRef}
+              sx={{ mb: 2 }}
+              autoComplete="off"
+            />
+
+            {isAnswerRevealed && (
+              <Box mb={1}>
+                <Alert icon={<CheckCircle />} severity="info">
+                  Correct answer: <strong>{currentWord.english}</strong>
+                </Alert>
+              </Box>
+            )}
+
+            {isExampleRevealed && (
+              <Box mb={2}>
+                <Alert icon={<Info />} severity="info">
+                  English example revealed. Input is locked. Click Next to continue.
+                </Alert>
+              </Box>
+            )}
+
+            {result && (
+              <Box mb={2}>
+                {result.isCorrect ? (
+                  <Alert icon={<CheckCircle />} severity="success">
+                    Correct! Well done!
+                  </Alert>
+                ) : result.isSynonym ? (
+                  <Alert icon={<Info />} severity="info">
+                    This is synonym, try another word. Entered synonyms:<br></br>
+                    <ul style={{ margin: 0, paddingLeft: 20 }}>
+                      {enteredSynonyms.map((syn, idx) => (
+                        <li key={idx}><strong>{syn}</strong></li>
+                      ))}
+                    </ul>
+                  </Alert>
+                ) : result.isPartial ? (
+                  <Alert icon={<Info />} severity="info">
+                    {result.hint}
+                  </Alert>
+                ) : (
+                  <Alert icon={<Error />} severity="error">
+                    Incorrect. The correct answer is: <strong>{result.correctAnswer}</strong>
+                  </Alert>
+                )}
+              </Box>
+            )}
+
+            <Button
+              variant="text"
+              color="secondary"
+              fullWidth
+              sx={{ mt: 1, mb: 1 }}
+              onClick={() => setIsAnswerRevealed(true)}
+              disabled={isAnswerRevealed || Boolean(result && !result.isCorrect && !result.isPartial && !result.isSynonym)}
+            >
+              Show Answer
+            </Button>
+
+            <Button
+              type="submit"
+              variant="contained"
+              fullWidth
+              disabled={loading || !answer.trim() || result?.isCorrect || isExampleRevealed || isAnswerRevealed || Boolean(result && !result.isCorrect && !result.isPartial && !result.isSynonym)}
+            >
+              {loading ? 'Checking...' : 'Check Answer'}
+            </Button>
+          </form>
 
           <Button
             variant="text"
-            color="secondary"
             fullWidth
-            sx={{ mt: 1, mb: 1 }}
-            onClick={() => setIsAnswerRevealed(true)}
-            disabled={isAnswerRevealed || Boolean(result && !result.isCorrect && !result.isPartial && !result.isSynonym)}
+            sx={{ mt: 1 }}
+            disabled={loading}
+            onClick={() => {
+              setEnteredSynonyms([]);
+              if (autoAdvanceTimeoutRef.current) {
+                window.clearTimeout(autoAdvanceTimeoutRef.current);
+                autoAdvanceTimeoutRef.current = null;
+              }
+              if (result?.isCorrect) {
+                onWordCompleted();
+              }
+              loadNextWord(true);
+            }}
           >
-            Show Answer
+            Next
           </Button>
-
-          <Button
-            type="submit"
-            variant="contained"
-            fullWidth
-            disabled={loading || !answer.trim() || result?.isCorrect || isExampleRevealed || isAnswerRevealed || Boolean(result && !result.isCorrect && !result.isPartial && !result.isSynonym)}
-          >
-            {loading ? 'Checking...' : 'Check Answer'}
-          </Button>
-        </form>
-
-        <Button
-          variant="text"
-          fullWidth
-          sx={{ mt: 1 }}
-          disabled={loading}
-          onClick={() => {
-            setEnteredSynonyms([]);
-            if (autoAdvanceTimeoutRef.current) {
-              window.clearTimeout(autoAdvanceTimeoutRef.current);
-              autoAdvanceTimeoutRef.current = null;
-            }
-            if (result?.isCorrect) {
-              onWordCompleted();
-            }
-            loadNextWord(true);
-          }}
-        >
-          Next
-        </Button>
         </CardContent>
       </Card>
       <Snackbar
@@ -385,13 +387,19 @@ export const StudyCard: React.FC<StudyCardProps> = ({
         <Alert onClose={() => setSnackbarOpen(false)} severity="info" sx={{ width: '100%' }}>
           <Box sx={{ width: '100%' }}>
             <Typography variant="body2">
-              Correct answers today: {todayCorrectAnswers}/{totalWords}
+              Correct answers today: {todayCorrectAnswers}
             </Typography>
-            <LinearProgress
-              variant="determinate"
-              value={totalWords ? (todayCorrectAnswers / totalWords) * 100 : 0}
-              sx={{ mt: 1 }}
-            />
+          </Box>
+          <br></br>
+          <Box sx={{ width: '100%' }}>
+            <Typography variant="body2">
+              Total progress:
+              <LinearProgress
+                variant="determinate"
+                value={totalCorrectAnswers && totalWords ? (totalCorrectAnswers / totalWords) * 100 : 0}
+                sx={{ mt: 1 }}
+              />
+            </Typography>
           </Box>
         </Alert>
       </Snackbar>

--- a/client/src/components/StudyCard.tsx
+++ b/client/src/components/StudyCard.tsx
@@ -10,6 +10,12 @@ import {
   Chip,
   IconButton,
   Tooltip,
+  Snackbar,
+  Dialog,
+  DialogTitle,
+  DialogContent,
+  DialogActions,
+  LinearProgress,
 } from '@mui/material';
 import {
   Favorite,
@@ -17,8 +23,9 @@ import {
   CheckCircle,
   Error,
   Info,
+  Edit,
 } from '@mui/icons-material';
-import { Word, CheckAnswerResponse } from '../types';
+import { Word, CheckAnswerResponse, UpdateWordRequest } from '../types';
 import { wordsApi, answersApi } from '../services/api';
 
 interface StudyCardProps {
@@ -30,12 +37,26 @@ export const StudyCard: React.FC<StudyCardProps> = ({
   onWordCompleted, 
   favoriteOnly = false 
 }) => {
+  const [isAnswerRevealed, setIsAnswerRevealed] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [shouldFocusInput, setShouldFocusInput] = useState(false);
   const [currentWord, setCurrentWord] = useState<Word | null>(null);
   const [answer, setAnswer] = useState('');
   const [result, setResult] = useState<CheckAnswerResponse | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [isExampleRevealed, setIsExampleRevealed] = useState(false);
+  const [snackbarOpen, setSnackbarOpen] = useState(false);
+  const [todayCorrectAnswers, setTodayCorrectAnswers] = useState(0);
+  const [totalWords, setTotalWords] = useState(0);
+  const [editDialogOpen, setEditDialogOpen] = useState(false);
+  const [formData, setFormData] = useState<UpdateWordRequest>({
+    english: '',
+    russian: '',
+    exampleEn: '',
+    exampleRu: '',
+  });
+  const [enteredSynonyms, setEnteredSynonyms] = useState<string[]>([]);
   const autoAdvanceTimeoutRef = useRef<number | null>(null);
 
   const loadNextWord = async (excludeCurrent: boolean = false) => {
@@ -50,12 +71,23 @@ export const StudyCard: React.FC<StudyCardProps> = ({
       setAnswer('');
       setResult(null);
       setIsExampleRevealed(false);
+      setIsAnswerRevealed(false);
+      setShouldFocusInput(true);
     } catch (err: unknown) {
       setError('Failed to load word');
     } finally {
       setLoading(false);
     }
   };
+
+  useEffect(() => {
+    if (shouldFocusInput) {
+      setShouldFocusInput(false);
+      setTimeout(() => {
+        inputRef.current?.focus();
+      }, 0);
+    }
+  }, [shouldFocusInput, currentWord]);
 
   useEffect(() => {
     loadNextWord();
@@ -71,10 +103,19 @@ export const StudyCard: React.FC<StudyCardProps> = ({
         wordId: currentWord.id,
         answer: answer.trim(),
       });
-      
       setResult(result);
-      
+      setTodayCorrectAnswers(result.todayCorrectAnswers);
+      setTotalWords(result.totalWords);
+      if (result.isCorrect || result.isSynonym) {
+        setSnackbarOpen(true);
+      }
+      if (result.isSynonym) {
+        setEnteredSynonyms((prev) => [...prev, answer]);
+        setAnswer('');
+        setShouldFocusInput(true);
+      }
       if (result.isCorrect) {
+        setEnteredSynonyms([]);
         if (autoAdvanceTimeoutRef.current) {
           window.clearTimeout(autoAdvanceTimeoutRef.current);
           autoAdvanceTimeoutRef.current = null;
@@ -100,6 +141,33 @@ export const StudyCard: React.FC<StudyCardProps> = ({
       setCurrentWord(updatedWord);
     } catch (err: unknown) {
       setError('Failed to toggle favorite');
+    }
+  };
+
+  const handleEditOpen = () => {
+    if (!currentWord) return;
+    setFormData({
+      english: currentWord.english,
+      russian: currentWord.russian,
+      exampleEn: currentWord.exampleEn,
+      exampleRu: currentWord.exampleRu,
+    });
+    setEditDialogOpen(true);
+  };
+
+  const handleSaveEdit = async () => {
+    if (!currentWord) return;
+
+    try {
+      await wordsApi.update(currentWord.id, formData);
+      setEditDialogOpen(false);
+      if (autoAdvanceTimeoutRef.current) {
+        window.clearTimeout(autoAdvanceTimeoutRef.current);
+        autoAdvanceTimeoutRef.current = null;
+      }
+      loadNextWord(true);
+    } catch (err: unknown) {
+      setError('Failed to save word');
     }
   };
 
@@ -147,17 +215,25 @@ export const StudyCard: React.FC<StudyCardProps> = ({
   }
 
   return (
-    <Card sx={{ minWidth: 400, maxWidth: 600 }}>
-      <CardContent>
+    <>
+      <Card sx={{ minWidth: 400, maxWidth: 600 }}>
+        <CardContent>
         <Box display="flex" justifyContent="space-between" alignItems="center" mb={2}>
           <Typography variant="h5" component="div">
             {currentWord.russian}
           </Typography>
-          <Tooltip title={currentWord.isFavorite ? 'Remove from favorites' : 'Add to favorites'}>
-            <IconButton onClick={handleToggleFavorite} color="primary">
-              {currentWord.isFavorite ? <Favorite /> : <FavoriteBorder />}
-            </IconButton>
-          </Tooltip>
+          <Box display="flex" alignItems="center">
+            <Tooltip title={currentWord.isFavorite ? 'Remove from favorites' : 'Add to favorites'}>
+              <IconButton onClick={handleToggleFavorite} color="primary">
+                {currentWord.isFavorite ? <Favorite /> : <FavoriteBorder />}
+              </IconButton>
+            </Tooltip>
+            <Tooltip title="Edit word">
+              <IconButton onClick={handleEditOpen} color="primary">
+                <Edit />
+              </IconButton>
+            </Tooltip>
+          </Box>
         </Box>
 
         <Box mb={3}>
@@ -202,16 +278,26 @@ export const StudyCard: React.FC<StudyCardProps> = ({
           </Box>
         </Box>
 
-        <form onSubmit={handleSubmit}>
+  <form onSubmit={handleSubmit}>
+
           <TextField
             fullWidth
             label="Enter English word"
             value={answer}
             onChange={(e) => setAnswer(e.target.value)}
-            disabled={loading || result?.isCorrect || isExampleRevealed}
-            autoFocus
+            disabled={loading || result?.isCorrect || isExampleRevealed || isAnswerRevealed}
+            inputRef={inputRef}
             sx={{ mb: 2 }}
+            autoComplete="off"
           />
+
+          {isAnswerRevealed && (
+            <Box mb={1}>
+              <Alert icon={<CheckCircle />} severity="info">
+                Correct answer: <strong>{currentWord.english}</strong>
+              </Alert>
+            </Box>
+          )}
 
           {isExampleRevealed && (
             <Box mb={2}>
@@ -229,7 +315,12 @@ export const StudyCard: React.FC<StudyCardProps> = ({
                 </Alert>
               ) : result.isSynonym ? (
                 <Alert icon={<Info />} severity="info">
-                  Это синоним. Попробуйте другое слово.
+                  This is synonym, try another word. Entered synonyms:<br></br>
+                  <ul style={{ margin: 0, paddingLeft: 20 }}>
+                    {enteredSynonyms.map((syn, idx) => (
+                      <li key={idx}><strong>{syn}</strong></li>
+                    ))}
+                  </ul>
                 </Alert>
               ) : result.isPartial ? (
                 <Alert icon={<Info />} severity="info">
@@ -244,28 +335,25 @@ export const StudyCard: React.FC<StudyCardProps> = ({
           )}
 
           <Button
+            variant="text"
+            color="secondary"
+            fullWidth
+            sx={{ mt: 1, mb: 1 }}
+            onClick={() => setIsAnswerRevealed(true)}
+            disabled={isAnswerRevealed || Boolean(result && !result.isCorrect && !result.isPartial && !result.isSynonym)}
+          >
+            Show Answer
+          </Button>
+
+          <Button
             type="submit"
             variant="contained"
             fullWidth
-            disabled={loading || !answer.trim() || result?.isCorrect || isExampleRevealed}
+            disabled={loading || !answer.trim() || result?.isCorrect || isExampleRevealed || isAnswerRevealed || Boolean(result && !result.isCorrect && !result.isPartial && !result.isSynonym)}
           >
             {loading ? 'Checking...' : 'Check Answer'}
           </Button>
         </form>
-
-        {result && !result.isCorrect && (
-          <Button
-            variant="outlined"
-            fullWidth
-            sx={{ mt: 1 }}
-            onClick={() => {
-              setAnswer('');
-              setResult(null);
-            }}
-          >
-            Try Again
-          </Button>
-        )}
 
         <Button
           variant="text"
@@ -273,6 +361,7 @@ export const StudyCard: React.FC<StudyCardProps> = ({
           sx={{ mt: 1 }}
           disabled={loading}
           onClick={() => {
+            setEnteredSynonyms([]);
             if (autoAdvanceTimeoutRef.current) {
               window.clearTimeout(autoAdvanceTimeoutRef.current);
               autoAdvanceTimeoutRef.current = null;
@@ -285,7 +374,69 @@ export const StudyCard: React.FC<StudyCardProps> = ({
         >
           Next
         </Button>
-      </CardContent>
-    </Card>
+        </CardContent>
+      </Card>
+      <Snackbar
+        open={snackbarOpen}
+        autoHideDuration={3000}
+        onClose={() => setSnackbarOpen(false)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      >
+        <Alert onClose={() => setSnackbarOpen(false)} severity="info" sx={{ width: '100%' }}>
+          <Box sx={{ width: '100%' }}>
+            <Typography variant="body2">
+              Correct answers today: {todayCorrectAnswers}/{totalWords}
+            </Typography>
+            <LinearProgress
+              variant="determinate"
+              value={totalWords ? (todayCorrectAnswers / totalWords) * 100 : 0}
+              sx={{ mt: 1 }}
+            />
+          </Box>
+        </Alert>
+      </Snackbar>
+
+      <Dialog open={editDialogOpen} onClose={() => setEditDialogOpen(false)} maxWidth="sm" fullWidth>
+        <DialogTitle>Edit Word</DialogTitle>
+        <DialogContent>
+          <TextField
+            fullWidth
+            label="English"
+            value={formData.english}
+            onChange={(e) => setFormData({ ...formData, english: e.target.value })}
+            margin="normal"
+          />
+          <TextField
+            fullWidth
+            label="Russian"
+            value={formData.russian}
+            onChange={(e) => setFormData({ ...formData, russian: e.target.value })}
+            margin="normal"
+          />
+          <TextField
+            fullWidth
+            label="Example (English)"
+            value={formData.exampleEn}
+            onChange={(e) => setFormData({ ...formData, exampleEn: e.target.value })}
+            margin="normal"
+            multiline
+            rows={2}
+          />
+          <TextField
+            fullWidth
+            label="Example (Russian)"
+            value={formData.exampleRu}
+            onChange={(e) => setFormData({ ...formData, exampleRu: e.target.value })}
+            margin="normal"
+            multiline
+            rows={2}
+          />
+        </DialogContent>
+        <DialogActions>
+          <Button onClick={() => setEditDialogOpen(false)}>Cancel</Button>
+          <Button onClick={handleSaveEdit} variant="contained">Save</Button>
+        </DialogActions>
+      </Dialog>
+    </>
   );
 };

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -45,6 +45,7 @@ export interface CheckAnswerResponse {
   isSynonym?: boolean;
   correctAnswer: string;
   todayCorrectAnswers: number;
+  totalCorrectAnswers: number;
   totalWords: number;
 }
 

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -44,6 +44,8 @@ export interface CheckAnswerResponse {
   hint?: string;
   isSynonym?: boolean;
   correctAnswer: string;
+  todayCorrectAnswers: number;
+  totalWords: number;
 }
 
 export interface ApiResponse<T> {

--- a/server/routes/answers.ts
+++ b/server/routes/answers.ts
@@ -117,6 +117,12 @@ router.post('/check', async (req: Request<{}, {}, CheckAnswerRequest>, res: Resp
       }
     });
 
+    const totalCorrectAnswers = await prisma.answer.count({
+      where: {
+        isCorrect: true,
+      }
+    });
+
     const totalWords = await prisma.word.count();
 
     const response: CheckAnswerResponse = {
@@ -126,6 +132,7 @@ router.post('/check', async (req: Request<{}, {}, CheckAnswerRequest>, res: Resp
       isSynonym: isSynonym || undefined,
       correctAnswer: word.english,
       todayCorrectAnswers,
+      totalCorrectAnswers,
       totalWords
     };
     

--- a/server/types/index.ts
+++ b/server/types/index.ts
@@ -45,6 +45,7 @@ export interface CheckAnswerResponse {
   isSynonym?: boolean;
   correctAnswer: string;
   todayCorrectAnswers: number;
+  totalCorrectAnswers: number;
   totalWords: number;
 }
 

--- a/server/types/index.ts
+++ b/server/types/index.ts
@@ -44,6 +44,8 @@ export interface CheckAnswerResponse {
   hint?: string;
   isSynonym?: boolean;
   correctAnswer: string;
+  todayCorrectAnswers: number;
+  totalWords: number;
 }
 
 export interface WordWithAnswers extends Word {


### PR DESCRIPTION
## Summary
- show bottom-right Snackbar after correct answers or accepted synonyms, with today's correct count and overall progress
- record synonym answers as learned and return daily correct stats and total word count
- add Dockerfile and GitHub Actions workflow to deploy to EC2 using variables
- merge latest `main` and resolve conflicts in StudyCard

## Testing
- `npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68a43533e7fc832bbbaff2dc0abc663b